### PR TITLE
Use current branch in remote_status instead of hard-coded "master"

### DIFF
--- a/lib/git/status_all.rb
+++ b/lib/git/status_all.rb
@@ -84,8 +84,8 @@ module Git
 				return "no origin".black.on_yellow
 			end
 
-			if !g.branches[:master].up_to_date?
-				b = g.branches[:master]
+			if !g.branches.current.up_to_date?
+				b = g.branches.current
 				
 				s = ''
 				s += "#{b.behind_count}\u2193" if b.behind_count > 0


### PR DESCRIPTION
This prevents an error in case there is no master branch and seems to make more sense anyway.
Fixes #1.

Note: I do not have any experience with Ruby. The proposed change is a bit trial-and-error but it seems to work for me.