### PR TITLE
upgrade to optimist (fixes reednj/git-status-all#3)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,26 +1,27 @@
 PATH
   remote: .
   specs:
-    git-status-all (1.1.2)
+    git-status-all (1.1.4)
       colorize
       git (~> 1.3)
-      trollop
+      optimist (~> 3.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     colorize (0.8.1)
-    git (1.3.0)
+    git (1.5.0)
+    optimist (3.0.0)
     rake (10.5.0)
-    trollop (2.1.2)
 
 PLATFORMS
   ruby
+  x64-mingw32
 
 DEPENDENCIES
-  bundler (~> 1.12)
+  bundler (~> 2.0)
   git-status-all!
   rake (~> 10.0)
 
 BUNDLED WITH
-   1.13.6
+   2.0.1

--- a/git-status_all.gemspec
+++ b/git-status_all.gemspec
@@ -18,11 +18,11 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.12"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
 
   spec.required_ruby_version = '>=1.9.3'
   spec.add_dependency  'colorize'
-  spec.add_dependency  'trollop'
+  spec.add_dependency  'optimist', "~> 3.0"
   spec.add_dependency  'git', "~> 1.3"
 end

--- a/lib/git/status_all.rb
+++ b/lib/git/status_all.rb
@@ -1,6 +1,6 @@
 require 'git'
 require 'colorize'
-require 'trollop'
+require 'optimist'
 
 require "git/status_all/version"
 require "git/status_all/extensions"
@@ -15,7 +15,7 @@ module Git
 			# the colors
 			String.disable_colorization = !$stdout.isatty
 			
-			opts = Trollop::options do
+			opts = Optimist::options do
 				version "git-status-all #{Git::StatusAll::VERSION} (c) 2016 @reednj (reednj@gmail.com)"
 				banner "Usage: git-status-all [options] [path]"
 				opt :fetch, "perform fetch for each repository before getting status", :default => false

--- a/lib/git/status_all/version.rb
+++ b/lib/git/status_all/version.rb
@@ -1,5 +1,5 @@
 module Git
   module StatusAll
-    VERSION = "1.1.3"
+    VERSION = "1.1.4"
   end
 end

--- a/status-all-test
+++ b/status-all-test
@@ -1,2 +1,3 @@
 #!/bin/bash
-bundle exec exe/git-status-all "$@"
+# exec ruby avoids the "not executable" error in bundler on x64-mingw32
+bundle exec ruby exe/git-status-all "$@"


### PR DESCRIPTION
Hi Nathan, Please could you review/merge this change -- it fixes a runtime warning in v1.1.13, which is caused by a rename of trollop gem to "optimist". Please note that the bundler has added x64-mingw32 as the platform (might be worth checking if 'bundle install' works ok on linux/macos). Thanks!